### PR TITLE
Add an argument to change the remote_port used

### DIFF
--- a/server/dhcpd.c
+++ b/server/dhcpd.c
@@ -433,6 +433,12 @@ main(int argc, char **argv) {
 			local_port = validate_port (argv [i]);
 			log_debug ("binding to user-specified port %d",
 			       ntohs (local_port));
+		} else if (!strcmp (argv [i], "--remote-port")) {
+			if (++i == argc)
+				usage(use_noarg, argv[i-1]);
+			remote_port = validate_port (argv [i]);
+			log_debug ("binding to user-specified remote port %d",
+			       ntohs (remote_port));
 		} else if (!strcmp (argv [i], "-f")) {
 #ifndef DEBUG
 			/* daemon = 0; */
@@ -706,7 +712,11 @@ main(int argc, char **argv) {
 	}
 
   	if (local_family == AF_INET) {
-		remote_port = htons(ntohs(local_port) + 1);
+		if(!remote_port){
+			remote_port = htons(ntohs(local_port) + 1);
+		} else {
+			log_info("Remote port already set : %d", ntohs(remote_port));
+		}
 	} else {
 		/* INSIST(local_family == AF_INET6); */
 		ent = getservbyname("dhcpv6-client", "udp");


### PR DESCRIPTION
Currently, we have the possibility to change the listening port with the argument "-p" but the remote port where the reply is send is necessarily the local_port + 1. For example if I use "-p 28067" the reply port will be 28068.
For a project, I have to use another port so I add the parameter "--remote-port" in order to have the possibility to modify the reply port independently of the listening port