### PR TITLE
Update dhcpd.conf.5, add prefix6 delegation end range hint

### DIFF
--- a/server/dhcpd.conf.5
+++ b/server/dhcpd.conf.5
@@ -1597,8 +1597,8 @@ from the \fIrange6\fR, as are IPv6 addresses on the server itself.
 .fi
 .PP
 The \fIprefix6\fR is the \fIrange6\fR equivalent for Prefix Delegation
-(RFC 3633). Prefixes of \fIbits\fR length are assigned between
-\fIlow-address\fR and \fIhigh-address\fR.
+(RFC 3633). Prefixes of \fIbits\fR length are assigned within
+\fIlow-address\fR and \fIhigh-address\fR, including \fIhigh-address\fR.
 .PP
 Any IPv6 prefixes given to static entries (hosts) with \fIfixed-prefix6\fR
 are excluded from the \fIprefix6\fR.


### PR DESCRIPTION
Adding a hint that high-address is the the actual last delegated prefix and used as well. This clarifies a bit that this is not a "within a network range" setting.